### PR TITLE
Added "Error: " prefix in _exit_err()

### DIFF
--- a/ccollect
+++ b/ccollect
@@ -78,7 +78,7 @@ _techo()
 # exit on error
 _exit_err()
 {
-    _techo "$@"
+    _techo "Error: $@"
     rm -f "${TMP}"
     exit 1
 }


### PR DESCRIPTION
All stdout generated with the _exit_err() function gets a prefix:
"Error: " for better usability.
