### PR TITLE
Fix missing hostname for final "Finished" log message

### DIFF
--- a/ccollect
+++ b/ccollect
@@ -561,4 +561,4 @@ if [ -x "${CPOSTEXEC}" ]; then
 fi
 
 rm -f "${TMP}"
-_techo "Finished"
+_techo "Finished" | add_name


### PR DESCRIPTION
Running ccollect in parallel across a bunch of hosts generates a lot of log messages, most of which are useful except for the very final "Finished" message, which is missing a hostname.

This fixes the issue. FFTTMTFO etc ;)

Cheers

R.
