### PR TITLE
Bugfix: empty rsync_options line causes destroying source.

### DIFF
--- a/ccollect
+++ b/ccollect
@@ -655,7 +655,15 @@ while [ "${source_no}" -lt "${no_sources}" ]; do
     #
     if [ -f "${c_rsync_options}" ]; then
         while read line; do
-            set -- "$@" "${line}"
+            # Only if ln is non zero length string (read trims line).
+            #
+            # If line is empty then rsync '' DEST evaluates
+            # to transfer current directory to DEST which would
+            # with specific options destroy DEST content.
+            if [ -n "${line}" ]
+            then
+                set -- "$@" "${line}"
+            fi
         done < "${c_rsync_options}"
     fi
 

--- a/ccollect
+++ b/ccollect
@@ -655,14 +655,16 @@ while [ "${source_no}" -lt "${no_sources}" ]; do
     #
     if [ -f "${c_rsync_options}" ]; then
         while read line; do
-            # Only if line is non zero length string (read trims line).
+            # Trime line.
+            ln=$(echo "${line}" | awk '{$1=$1;print;}')
+            # Only if ln is non zero length string.
             #
-            # If line is empty then rsync '' DEST evaluates
+            # If ln is empty then rsync '' DEST evaluates
             # to transfer current directory to DEST which would
             # with specific options destroy DEST content.
-            if [ -n "${line}" ]
+            if [ -n "${ln}" ]
             then
-                set -- "$@" "${line}"
+                set -- "$@" "${ln}"
             fi
         done < "${c_rsync_options}"
     fi

--- a/ccollect
+++ b/ccollect
@@ -655,7 +655,7 @@ while [ "${source_no}" -lt "${no_sources}" ]; do
     #
     if [ -f "${c_rsync_options}" ]; then
         while read line; do
-            # Trime line.
+            # Trim line.
             ln=$(echo "${line}" | awk '{$1=$1;print;}')
             # Only if ln is non zero length string.
             #

--- a/ccollect
+++ b/ccollect
@@ -655,7 +655,7 @@ while [ "${source_no}" -lt "${no_sources}" ]; do
     #
     if [ -f "${c_rsync_options}" ]; then
         while read line; do
-            # Only if ln is non zero length string (read trims line).
+            # Only if line is non zero length string (read trims line).
             #
             # If line is empty then rsync '' DEST evaluates
             # to transfer current directory to DEST which would


### PR DESCRIPTION
> Hello, my name is Takashi Akiyama.
>
> I'm sorry. I sent a mail without a subject and I will resend it.
>
> I have been using ccollect since Ver.0.8 and I really appreciate your software.
> Few days ago, I have updated server and at same time, updated to Ver. 2.1.
> However, I tried to backup with rsync_option file which contain a blank line caused to destroy source directory.
>
> I attached succeeded log and log when problem happened.
>
> I am guessing that a blank line was interpreted as  '' then while executing "Check: source is up and accepting connections",
> rsync "$@" "${source}" was sent from current directory to ${source}.
>
> Will you change to disregard a blank line in rsync_options?
> I personally feel safe to ignore all if it does not beginning with '-' on line.
>
> Best Regards
> Akiyama
>
>
> ccollect -v daily test_job
> + shift
> + '[' 2 -ge 1 ']'
> + case "$1" in
> + break
> + '[' '' ']'
> + _is_interactive
> + '[' -t 0 -o -p /dev/stdin ']'
> + '[' '' ']'
> + _techof=_techo_stdout
> + LOGLEVEL=e
> + '[' '' -o '' ']'
> + echo ''
> + grep -q -E '^[1-9][0-9]*$|^$'
> + '[' 0 -ne 0 ']'
> + '[' 2 -ge 1 ']'
> + export INTERVAL=daily
> + INTERVAL=daily
> + shift
> + '[' -d /etc/ccollect ']'
> + export no_sources=0
> + no_sources=0
> + '[' '' = 1 ']'
> + '[' 1 -ge 1 ']'
> + eval 'arg="$1"'
> ++ arg=test_job
> + shift
> + eval export 'source_0="test_job"'
> ++ export source_0=test_job
> ++ source_0=test_job
> + no_sources=1
> + '[' 0 -ge 1 ']'
> + '[' 1 -lt 1 ']'
> + _techo 'ccollect 2.1: Beginning backup using interval daily'
> + '[' e = a ']'
> + '[' -x /etc/ccollect/defaults/pre_exec ']'
> + '[' '' ']'
> + source_no=0
> + '[' 0 -lt 1 ']'
> + eval export 'name="$source_0"'
> ++ export name=test_job
> ++ name=test_job
> + source_no=1
> + '[' '' ']'
> + backup=/etc/ccollect/sources/test_job
> + c_source=/etc/ccollect/sources/test_job/source
> + c_dest=/etc/ccollect/sources/test_job/destination
> + add_name
> + awk '{ print "[test_job] " $0 }'
> + c_pre_exec=/etc/ccollect/sources/test_job/pre_exec
> + c_post_exec=/etc/ccollect/sources/test_job/post_exec
> + exec
> [test_job] ++ date +%s
> [test_job] + begin_s=1504243082
> [test_job] + _techo 'Beginning to backup'
> [test_job] + '[' e = a ']'
> [test_job] + '[' '!' -e /etc/ccollect/sources/test_job ']'
> [test_job] + '[' '!' -d /etc/ccollect/sources/test_job ']'
> [test_job] + lock test_job
> [test_job] + lock_flock test_job
> [test_job] ++ printf ccollect_%s.lock test_job
> [test_job] + lockfile=/etc/ccollect/ccollect_test_job.lock
> [test_job] + eval 'exec 4> /etc/ccollect/ccollect_test_job.lock'
> [test_job] ++ exec
> [test_job] + flock -n 4
> [test_job] + return 0
> [test_job] + TRAPFUNC='rm -f "/tmp/ccollect.llpjD2"; unlock "test_job"'
> [test_job] + trap 'rm -f "/tmp/ccollect.llpjD2"; unlock "test_job"' 1 2 15
> [test_job] + '[' -x /etc/ccollect/sources/test_job/pre_exec ']'
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/verbose -o -f /etc/ccollect/sources/test_job/no_verbose ']'
> [test_job] + eval 'c_verbose="/etc/ccollect/defaults/verbose"'
> [test_job] ++ c_verbose=/etc/ccollect/defaults/verbose
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/very_verbose -o -f /etc/ccollect/sources/test_job/no_very_verbose ']'
> [test_job] + eval 'c_very_verbose="/etc/ccollect/defaults/very_verbose"'
> [test_job] ++ c_very_verbose=/etc/ccollect/defaults/very_verbose
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/summary -o -f /etc/ccollect/sources/test_job/no_summary ']'
> [test_job] + eval 'c_summary="/etc/ccollect/defaults/summary"'
> [test_job] ++ c_summary=/etc/ccollect/defaults/summary
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/exclude -o -f /etc/ccollect/sources/test_job/no_exclude ']'
> [test_job] + eval 'c_exclude="/etc/ccollect/defaults/exclude"'
> [test_job] ++ c_exclude=/etc/ccollect/defaults/exclude
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/rsync_options -o -f /etc/ccollect/sources/test_job/no_rsync_options ']'
> [test_job] + eval 'c_rsync_options="/etc/ccollect/defaults/rsync_options"'
> [test_job] ++ c_rsync_options=/etc/ccollect/defaults/rsync_options
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/delete_incomplete -o -f /etc/ccollect/sources/test_job/no_delete_incomplete ']'
> [test_job] + eval 'c_delete_incomplete="/etc/ccollect/defaults/delete_incomplete"'
> [test_job] ++ c_delete_incomplete=/etc/ccollect/defaults/delete_incomplete
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/rsync_failure_codes -o -f /etc/ccollect/sources/test_job/no_rsync_failure_codes ']'
> [test_job] + eval 'c_rsync_failure_codes="/etc/ccollect/defaults/rsync_failure_codes"'
> [test_job] ++ c_rsync_failure_codes=/etc/ccollect/defaults/rsync_failure_codes
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/mtime -o -f /etc/ccollect/sources/test_job/no_mtime ']'
> [test_job] + eval 'c_mtime="/etc/ccollect/defaults/mtime"'
> [test_job] ++ c_mtime=/etc/ccollect/defaults/mtime
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/quiet_if_down -o -f /etc/ccollect/sources/test_job/no_quiet_if_down ']'
> [test_job] + eval 'c_quiet_if_down="/etc/ccollect/defaults/quiet_if_down"'
> [test_job] ++ c_quiet_if_down=/etc/ccollect/defaults/quiet_if_down
> [test_job] ++ cat /etc/ccollect/sources/test_job/intervals/daily
> [test_job] + c_interval=
> [test_job] + '[' -z '' ']'
> [test_job] ++ cat /etc/ccollect/defaults/intervals/daily
> [test_job] + c_interval=30
> [test_job] + '[' -z 30 ']'
> [test_job] + '[' -f /etc/ccollect/defaults/mtime ']'
> [test_job] + TSORT=tc
> [test_job] + '[' '!' -f /etc/ccollect/sources/test_job/source ']'
> [test_job] ++ cat /etc/ccollect/sources/test_job/source
> [test_job] + source=root@predev2:/root/ccollect/src
> [test_job] + ret=0
> [test_job] + '[' 0 -ne 0 ']'
> [test_job] + '[' '!' -f /etc/ccollect/sources/test_job/destination ']'
> [test_job] ++ cat /etc/ccollect/sources/test_job/destination
> [test_job] + ddir=/root/ccollect/dst
> [test_job] + ret=0
> [test_job] + '[' 0 -ne 0 ']'
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse
> [test_job] + '[' -f /etc/ccollect/defaults/exclude ']'
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude
> [test_job] + '[' -f /etc/ccollect/defaults/summary ']'
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats
> [test_job] + VVERBOSE=
> [test_job] + '[' -f /etc/ccollect/defaults/very_verbose ']'
> [test_job] + '[' -f /etc/ccollect/defaults/verbose ']'
> [test_job] + '[' -f /etc/ccollect/defaults/rsync_options ']'
> [test_job] + read line
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a
> [test_job] + read line
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A
> [test_job] + read line
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X
> [test_job] + read line
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X -H
> [test_job] + read line
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X -H '-e rsh'
> [test_job] + read line
> [test_job] + rsync --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X -H '-e rsh' root@predev2:/root/ccollect/src
> [test_job] + set -- --archive --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X -H '-e rsh'
> [test_job] + cd /root/ccollect/dst
> [test_job] + ls -1
> [test_job] + grep '.ccollect-marker$'
> [test_job] + ret=1
> [test_job] + '[' 1 -eq 0 ']'
> [test_job] ++ ls -1
> [test_job] ++ grep -c '^daily\.'
> [test_job] + count=0
> [test_job] + _techo 'Existing backups: 0 Total keeping backups: 30'
> [test_job] + '[' e = a ']'
> [test_job] + '[' 0 -ge 30 ']'
> [test_job] ++ ls -tcp1
> [test_job] ++ grep '/$'
> [test_job] ++ head -n 1
> [test_job] + last_dir=
> [test_job] + '[' '' ']'
> [test_job] ++ date +%Y%m%d-%H%M
> [test_job] + export destination_name=daily.20170901-1418.11350-1
> [test_job] + destination_name=daily.20170901-1418.11350-1
> [test_job] + export destination_dir=/root/ccollect/dst/daily.20170901-1418.11350-1
> [test_job] + destination_dir=/root/ccollect/dst/daily.20170901-1418.11350-1
> [test_job] + touch /root/ccollect/dst/daily.20170901-1418.11350-1.ccollect-marker
> [test_job] + cd /usr/local/bin
> [test_job] + _techo 'Transferring files...'
> [test_job] + '[' e = a ']'
> [test_job] + rsync --archive --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X -H '-e rsh' root@predev2:/root/ccollect/src /root/ccollect/dst/daily.20170901-1418.11350-1
> [test_job]
> [test_job] Number of files: 4 (reg: 1, dir: 3)
> [test_job] Number of created files: 4 (reg: 1, dir: 3)
> [test_job] Number of deleted files: 0
> [test_job] Number of regular files transferred: 1
> [test_job] Total file size: 0 bytes
> [test_job] Total transferred file size: 0 bytes
> [test_job] Literal data: 0 bytes
> [test_job] Matched data: 0 bytes
> [test_job] File list size: 138
> [test_job] File list generation time: 0.001 seconds
> [test_job] File list transfer time: 0.000 seconds
> [test_job] Total bytes sent: 89
> [test_job] Total bytes received: 204
> [test_job]
> [test_job] sent 89 bytes  received 204 bytes  586.00 bytes/sec
> [test_job] total size is 0  speedup is 0.00
> [test_job] + ret=0
> [test_job] + _techo 'Finished backup (rsync return code: 0).'
> [test_job] + '[' e = a ']'
> [test_job] + '[' -f /etc/ccollect/defaults/mtime ']'
> [test_job] + fail=
> [test_job] + '[' -f /etc/ccollect/defaults/rsync_failure_codes ']'
> [test_job] + '[' -z '' ']'
> [test_job] + rm /root/ccollect/dst/daily.20170901-1418.11350-1.ccollect-marker
> [test_job] + '[' 0 -ne 0 ']'
> [test_job] + '[' -x /etc/ccollect/sources/test_job/post_exec ']'
> [test_job] ++ date +%s
> [test_job] + end_s=1504243082
> [test_job] + full_seconds=0
> [test_job] + hours=0
> [test_job] + minutes=0
> [test_job] + seconds=0
> [test_job] + _techo 'Backup lasted: 0:0:0 (h:m:s)'
> [test_job] + '[' e = a ']'
> [test_job] + unlock test_job
> [test_job] + unlock_flock test_job
> [test_job] ++ printf ccollect_%s.lock test_job
> [test_job] + lockfile=/etc/ccollect/ccollect_test_job.lock
> [test_job] + eval 'exec 4>&-'
> [test_job] ++ exec
> [test_job] + rm -f /etc/ccollect/ccollect_test_job.lock
> + '[' 1 -lt 1 ']'
> + '[' '' ']'
> + '[' -x /etc/ccollect/defaults/post_exec ']'
> + rm -f /tmp/ccollect.llpjD2
> + _techo Finished
> + '[' e = a ']'
> ccollect -v daily test_job
> + shift
> + '[' 2 -ge 1 ']'
> + case "$1" in
> + break
> + '[' '' ']'
> + _is_interactive
> + '[' -t 0 -o -p /dev/stdin ']'
> + '[' '' ']'
> + _techof=_techo_stdout
> + LOGLEVEL=e
> + '[' '' -o '' ']'
> + echo ''
> + grep -q -E '^[1-9][0-9]*$|^$'
> + '[' 0 -ne 0 ']'
> + '[' 2 -ge 1 ']'
> + export INTERVAL=daily
> + INTERVAL=daily
> + shift
> + '[' -d /etc/ccollect ']'
> + export no_sources=0
> + no_sources=0
> + '[' '' = 1 ']'
> + '[' 1 -ge 1 ']'
> + eval 'arg="$1"'
> ++ arg=test_job
> + shift
> + eval export 'source_0="test_job"'
> ++ export source_0=test_job
> ++ source_0=test_job
> + no_sources=1
> + '[' 0 -ge 1 ']'
> + '[' 1 -lt 1 ']'
> + _techo 'ccollect 2.1: Beginning backup using interval daily'
> + '[' e = a ']'
> + '[' -x /etc/ccollect/defaults/pre_exec ']'
> + '[' '' ']'
> + source_no=0
> + '[' 0 -lt 1 ']'
> + eval export 'name="$source_0"'
> ++ export name=test_job
> ++ name=test_job
> + source_no=1
> + '[' '' ']'
> + backup=/etc/ccollect/sources/test_job
> + c_source=/etc/ccollect/sources/test_job/source
> + c_dest=/etc/ccollect/sources/test_job/destination
> + c_pre_exec=/etc/ccollect/sources/test_job/pre_exec
> + add_name
> + awk '{ print "[test_job] " $0 }'
> + c_post_exec=/etc/ccollect/sources/test_job/post_exec
> + exec
> [test_job] ++ date +%s
> [test_job] + begin_s=1504242301
> [test_job] + _techo 'Beginning to backup'
> [test_job] + '[' e = a ']'
> [test_job] + '[' '!' -e /etc/ccollect/sources/test_job ']'
> [test_job] + '[' '!' -d /etc/ccollect/sources/test_job ']'
> [test_job] + lock test_job
> [test_job] + lock_flock test_job
> [test_job] ++ printf ccollect_%s.lock test_job
> [test_job] + lockfile=/etc/ccollect/ccollect_test_job.lock
> [test_job] + eval 'exec 4> /etc/ccollect/ccollect_test_job.lock'
> [test_job] ++ exec
> [test_job] + flock -n 4
> [test_job] + return 0
> [test_job] + TRAPFUNC='rm -f "/tmp/ccollect.2pGR5H"; unlock "test_job"'
> [test_job] + trap 'rm -f "/tmp/ccollect.2pGR5H"; unlock "test_job"' 1 2 15
> [test_job] + '[' -x /etc/ccollect/sources/test_job/pre_exec ']'
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/verbose -o -f /etc/ccollect/sources/test_job/no_verbose ']'
> [test_job] + eval 'c_verbose="/etc/ccollect/defaults/verbose"'
> [test_job] ++ c_verbose=/etc/ccollect/defaults/verbose
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/very_verbose -o -f /etc/ccollect/sources/test_job/no_very_verbose ']'
> [test_job] + eval 'c_very_verbose="/etc/ccollect/defaults/very_verbose"'
> [test_job] ++ c_very_verbose=/etc/ccollect/defaults/very_verbose
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/summary -o -f /etc/ccollect/sources/test_job/no_summary ']'
> [test_job] + eval 'c_summary="/etc/ccollect/defaults/summary"'
> [test_job] ++ c_summary=/etc/ccollect/defaults/summary
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/exclude -o -f /etc/ccollect/sources/test_job/no_exclude ']'
> [test_job] + eval 'c_exclude="/etc/ccollect/defaults/exclude"'
> [test_job] ++ c_exclude=/etc/ccollect/defaults/exclude
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/rsync_options -o -f /etc/ccollect/sources/test_job/no_rsync_options ']'
> [test_job] + eval 'c_rsync_options="/etc/ccollect/defaults/rsync_options"'
> [test_job] ++ c_rsync_options=/etc/ccollect/defaults/rsync_options
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/delete_incomplete -o -f /etc/ccollect/sources/test_job/no_delete_incomplete ']'
> [test_job] + eval 'c_delete_incomplete="/etc/ccollect/defaults/delete_incomplete"'
> [test_job] ++ c_delete_incomplete=/etc/ccollect/defaults/delete_incomplete
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/rsync_failure_codes -o -f /etc/ccollect/sources/test_job/no_rsync_failure_codes ']'
> [test_job] + eval 'c_rsync_failure_codes="/etc/ccollect/defaults/rsync_failure_codes"'
> [test_job] ++ c_rsync_failure_codes=/etc/ccollect/defaults/rsync_failure_codes
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/mtime -o -f /etc/ccollect/sources/test_job/no_mtime ']'
> [test_job] + eval 'c_mtime="/etc/ccollect/defaults/mtime"'
> [test_job] ++ c_mtime=/etc/ccollect/defaults/mtime
> [test_job] + for opt in verbose very_verbose summary exclude rsync_options delete_incomplete rsync_failure_codes mtime quiet_if_down
> [test_job] + '[' -f /etc/ccollect/sources/test_job/quiet_if_down -o -f /etc/ccollect/sources/test_job/no_quiet_if_down ']'
> [test_job] + eval 'c_quiet_if_down="/etc/ccollect/defaults/quiet_if_down"'
> [test_job] ++ c_quiet_if_down=/etc/ccollect/defaults/quiet_if_down
> [test_job] ++ cat /etc/ccollect/sources/test_job/intervals/daily
> [test_job] + c_interval=
> [test_job] + '[' -z '' ']'
> [test_job] ++ cat /etc/ccollect/defaults/intervals/daily
> [test_job] + c_interval=30
> [test_job] + '[' -z 30 ']'
> [test_job] + '[' -f /etc/ccollect/defaults/mtime ']'
> [test_job] + TSORT=tc
> [test_job] + '[' '!' -f /etc/ccollect/sources/test_job/source ']'
> [test_job] ++ cat /etc/ccollect/sources/test_job/source
> [test_job] + source=root@predev2:/root/ccollect/src
> [test_job] + ret=0
> [test_job] + '[' 0 -ne 0 ']'
> [test_job] + '[' '!' -f /etc/ccollect/sources/test_job/destination ']'
> [test_job] ++ cat /etc/ccollect/sources/test_job/destination
> [test_job] + ddir=/root/ccollect/dst
> [test_job] + ret=0
> [test_job] + '[' 0 -ne 0 ']'
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse
> [test_job] + '[' -f /etc/ccollect/defaults/exclude ']'
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude
> [test_job] + '[' -f /etc/ccollect/defaults/summary ']'
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats
> [test_job] + VVERBOSE=
> [test_job] + '[' -f /etc/ccollect/defaults/very_verbose ']'
> [test_job] + '[' -f /etc/ccollect/defaults/verbose ']'
> [test_job] + '[' -f /etc/ccollect/defaults/rsync_options ']'
> [test_job] + read line
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a
> [test_job] + read line
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A
> [test_job] + read line
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X
> [test_job] + read line
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X -H
> [test_job] + read line
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X -H '-e rsh'
> [test_job] + read line
> [test_job] + set -- --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X -H '-e rsh' ''
> [test_job] + read line
> [test_job] + rsync --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X -H '-e rsh' '' root@predev2:/root/ccollect/src
> [test_job] + set -- --archive --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X -H '-e rsh' ''
> [test_job] + cd /root/ccollect/dst
> [test_job] + ls -1
> [test_job] + grep '.ccollect-marker$'
> [test_job] + ret=1
> [test_job] + '[' 1 -eq 0 ']'
> [test_job] ++ ls -1
> [test_job] ++ grep -c '^daily\.'
> [test_job] + count=0
> [test_job] + _techo 'Existing backups: 0 Total keeping backups: 30'
> [test_job] + '[' e = a ']'
> [test_job] + '[' 0 -ge 30 ']'
> [test_job] ++ ls -tcp1
> [test_job] ++ grep '/$'
> [test_job] ++ head -n 1
> [test_job] + last_dir=
> [test_job] + '[' '' ']'
> [test_job] ++ date +%Y%m%d-%H%M
> [test_job] + export destination_name=daily.20170901-1405.10984-1
> [test_job] + destination_name=daily.20170901-1405.10984-1
> [test_job] + export destination_dir=/root/ccollect/dst/daily.20170901-1405.10984-1
> [test_job] + destination_dir=/root/ccollect/dst/daily.20170901-1405.10984-1
> [test_job] + touch /root/ccollect/dst/daily.20170901-1405.10984-1.ccollect-marker
> [test_job] + cd /usr/local/bin
> [test_job] + _techo 'Transferring files...'
> [test_job] + '[' e = a ']'
> [test_job] + rsync --archive --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X -H '-e rsh' '' root@predev2:/root/ccollect/src /root/ccollect/dst/daily.20170901-1405.10984-1
> [test_job] Unexpected remote arg: root@predev2:/root/ccollect/src
> [test_job] rsync error: syntax or usage error (code 1) at main.c(1345) [sender=3.1.0]
> [test_job] + ret=1
> [test_job] + _techo 'Finished backup (rsync return code: 1).'
> [test_job] + '[' e = a ']'
> [test_job] + '[' -f /etc/ccollect/defaults/mtime ']'
> [test_job] + fail=
> [test_job] + '[' -f /etc/ccollect/defaults/rsync_failure_codes ']'
> [test_job] + '[' -z '' ']'
> [test_job] + rm /root/ccollect/dst/daily.20170901-1405.10984-1.ccollect-marker
> [test_job] + '[' 1 -ne 0 ']'
> [test_job] + _techo 'Warning: rsync exited non-zero, the backup may be broken (see rsync errors).'
> [test_job] + '[' e = a ']'
> [test_job] + '[' -x /etc/ccollect/sources/test_job/post_exec ']'
> [test_job] ++ date +%s
> [test_job] + end_s=1504242301
> [test_job] + full_seconds=0
> [test_job] + hours=0
> [test_job] + minutes=0
> [test_job] + seconds=0
> [test_job] + _techo 'Backup lasted: 0:0:0 (h:m:s)'
> [test_job] + '[' e = a ']'
> [test_job] + unlock test_job
> [test_job] + unlock_flock test_job
> [test_job] ++ printf ccollect_%s.lock test_job
> [test_job] + lockfile=/etc/ccollect/ccollect_test_job.lock
> [test_job] + eval 'exec 4>&-'
> [test_job] ++ exec
> [test_job] + rm -f /etc/ccollect/ccollect_test_job.lock
> + '[' 1 -lt 1 ']'
> + '[' '' ']'
> + '[' -x /etc/ccollect/defaults/post_exec ']'
> + rm -f /tmp/ccollect.2pGR5H
> + _techo Finished
> + '[' e = a ']'


With empty line in rsync_options rsync command became:
<pre>
rsync --delete --numeric-ids --relative --delete-excluded --sparse --exclude-from=/etc/ccollect/defaults/exclude --stats -a -A -X -H '-e rsh' '' root@predev2:/root/ccollect/src
</pre>
which, due to `'' root@predev2:/root/ccollect/src`, caused emptying root@predev2:/root/ccollect/src because of --delete option and because `''` is evaluated to current directory.

Empty length lines from rsync_options file should be skipped.